### PR TITLE
fix a bug where "onPermissionsGranted" was incorrectly called when a permissions request is interrupted

### DIFF
--- a/consent/src/main/java/com/seaplain/android/consent/Consent.java
+++ b/consent/src/main/java/com/seaplain/android/consent/Consent.java
@@ -64,6 +64,12 @@ public class Consent {
         PermissionRequest request = mPendingRequests.get(requestCode);
         if (request != null) {
             mPendingRequests.remove(requestCode);
+
+            if (permissions.length == 0 && grantResults.length == 0) {
+                // According to Activity#onRequestPermissionsResult, this means permissions request was cancelled.
+                return;
+            }
+
             DeclinedPermissions declinedPermissions = DeclinedPermissions.from(permissions, grantResults, request);
 
             if (declinedPermissions.isEmpty()) {


### PR DESCRIPTION
Fixes issue #1 